### PR TITLE
Serve hIPNAT (latest stable version)

### DIFF
--- a/populate_fiji.sh
+++ b/populate_fiji.sh
@@ -93,6 +93,9 @@ echo "--> Removing old joml"
 echo "--> Fetching jide-oss"
 (set -x; cx $FijiDirectory/jars && { curl -0 https://github.com/morphonets/SNT/raw/master/jars/jide-oss-3.7.7.jar ; cd -; } )
 
+echo "--> Fetching hIPNAT"
+(set -x; cx $FijiDirectory/jars && { curl -0 https://github.com/tferr/hIPNAT/releases/download/1.1.0/hIPNAT_-1.1.0.jar ; cd -; } )
+
 ## -- Put back jar/gluegen-rt and jar/jogl-all --
 #echo
 #echo "--> Reinstalling gluegen-rt, jogl-all, jocl, jinput, and ffmpeg"


### PR DESCRIPTION
This is mainly for backwards compatibility. See https://github.com/tferr/hIPNAT for details